### PR TITLE
fix: bump marimo to >=0.23.6 to fix import TypeError 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pre-commit = ">=4.1.0,<5"
 pre-commit-hooks = ">=5,<6"
 pytest = ">=9,<10"
 ruff = ">=0.15,<0.16"
-marimo = ">=0.23,<0.24"
+marimo = ">=0.23.6,<0.24"
 
 [tool.pixi.tasks]
 edit = "marimo edit src/app.py"


### PR DESCRIPTION
(narwhals typing compatibility)

marimo 0.23.1 fails on startup when building runtime unions with narwhals' IntoDataFrame (string alias). Require 0.23.6+ and refresh pixi.lock so `pixi run edit` works again.

Related to:
https://github.com/marimo-team/marimo/issues/9152

Original error message:
✨ Pixi task (edit): marimo edit src/app.py                                                                             Traceback (most recent call last):
  File "C:\Users\adiez_cmic\github_repos\marimo-pixi-starter-template\.pixi\envs\default\Scripts\marimo-script.py", line 6, in <module>
    from marimo._cli.cli import main
  File "C:\Users\adiez_cmic\github_repos\marimo-pixi-starter-template\.pixi\envs\default\Lib\site-packages\marimo\__init__.py", line 92, in <module>
    import marimo._ai as ai
  File "C:\Users\adiez_cmic\github_repos\marimo-pixi-starter-template\.pixi\envs\default\Lib\site-packages\marimo\_ai\__init__.py", line 11, in <module>
    from marimo._ai import llm
  File "C:\Users\adiez_cmic\github_repos\marimo-pixi-starter-template\.pixi\envs\default\Lib\site-packages\marimo\_ai\llm\__init__.py", line 3, in <module>
    from marimo._ai.llm._impl import (
    ...<6 lines>...
    )
  File "C:\Users\adiez_cmic\github_repos\marimo-pixi-starter-template\.pixi\envs\default\Lib\site-packages\marimo\_ai\llm\_impl.py", line 12, in <module>
    from marimo._plugins.ui._impl.chat.chat import AI_SDK_VERSION, DONE_CHUNK
  File "C:\Users\adiez_cmic\github_repos\marimo-pixi-starter-template\.pixi\envs\default\Lib\site-packages\marimo\_plugins\ui\__init__.py", line 47, in <module>
    from marimo._plugins.ui._impl.altair_chart import altair_chart
  File "C:\Users\adiez_cmic\github_repos\marimo-pixi-starter-template\.pixi\envs\default\Lib\site-packages\marimo\_plugins\ui\_impl\altair_chart.py", line 25, in <module>
    from marimo._plugins.ui._impl.charts.altair_transformer import (
    ...<2 lines>...
    )
  File "C:\Users\adiez_cmic\github_repos\marimo-pixi-starter-template\.pixi\envs\default\Lib\site-packages\marimo\_plugins\ui\_impl\charts\altair_transformer.py", line 25, in <module>
    Data = dict[Any, Any] | IntoDataFrame | nw.DataFrame[Any]
           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'str'